### PR TITLE
Add Yellowstone gRPC in launchpad logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5476,6 +5476,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "raydium-launchpad-logger"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "carbon-core",
+ "carbon-log-metrics",
+ "carbon-raydium-launchpad-decoder",
+ "carbon-yellowstone-grpc-datasource",
+ "dotenv",
+ "env_logger 0.11.8",
+ "log",
+ "rustls 0.23.27",
+ "serde_json",
+ "solana-instruction",
+ "tokio",
+ "yellowstone-grpc-proto",
+]
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/raydium-launchpad-logger/Cargo.toml
+++ b/examples/raydium-launchpad-logger/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "raydium-launchpad-logger"
+version = "0.1.0"
+edition = { workspace = true }
+
+[dependencies]
+carbon-core = { workspace = true }
+carbon-log-metrics = { workspace = true }
+carbon-raydium-launchpad-decoder = { workspace = true }
+carbon-yellowstone-grpc-datasource = { workspace = true }
+yellowstone-grpc-proto = { workspace = true }
+solana-instruction = { workspace = true }
+
+async-trait = { workspace = true }
+dotenv = { workspace = true }
+env_logger = { workspace = true }
+log = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+
+[dependencies.rustls]
+default-features = false
+features = ["std", "aws_lc_rs"]
+version = "0.23.0"

--- a/examples/raydium-launchpad-logger/README.md
+++ b/examples/raydium-launchpad-logger/README.md
@@ -1,0 +1,32 @@
+# Raydium Launchpad Logger
+
+This example shows how to create a Carbon pipeline that listens to the Raydium Launchpad program and logs every decoded instruction to a file in JSON format.
+
+## Setup
+
+1. Clone the repository and change into this directory:
+
+```sh
+git clone https://github.com/sevenlabs-hq/carbon.git
+cd examples/raydium-launchpad-logger
+```
+
+2. Create a `.env` file with:
+
+```env
+GEYSER_URL=...
+X_TOKEN=...
+LOG_PATH=raydium_launchpad_events.log
+RUST_LOG=info
+```
+
+`GEYSER_URL` should point to the Yellowstone gRPC endpoint. `X_TOKEN` can be set if the endpoint requires authentication. `LOG_PATH` specifies where the JSON log will be saved.
+
+3. Build and run:
+
+```sh
+cargo build --release
+cargo run --release
+```
+
+Each line in the file will contain a JSON object describing one Raydium Launchpad instruction.

--- a/examples/raydium-launchpad-logger/src/main.rs
+++ b/examples/raydium-launchpad-logger/src/main.rs
@@ -1,0 +1,105 @@
+use {
+    async_trait::async_trait,
+    carbon_core::{
+        error::CarbonResult,
+        instruction::{DecodedInstruction, InstructionMetadata, NestedInstructions},
+        metrics::MetricsCollection,
+        processor::Processor,
+    },
+    carbon_log_metrics::LogMetrics,
+    carbon_raydium_launchpad_decoder::{
+        instructions::RaydiumLaunchpadInstruction, RaydiumLaunchpadDecoder,
+        PROGRAM_ID as RAYDIUM_LAUNCHPAD_PROGRAM_ID,
+    },
+    carbon_yellowstone_grpc_datasource::YellowstoneGrpcGeyserClient,
+    yellowstone_grpc_proto::geyser::{CommitmentLevel, SubscribeRequestFilterTransactions},
+    std::{env, fs::OpenOptions, io::Write, sync::Arc},
+    tokio::sync::{Mutex, RwLock},
+    std::collections::{HashMap, HashSet},
+};
+
+#[tokio::main]
+pub async fn main() -> CarbonResult<()> {
+    dotenv::dotenv().ok();
+    env_logger::init();
+
+    // NOTE: Workaround to solve issue https://github.com/rustls/rustls/issues/1877
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("Can't set crypto provider to aws_lc_rs");
+
+    let transaction_filter = SubscribeRequestFilterTransactions {
+        vote: Some(false),
+        failed: Some(false),
+        account_include: vec![],
+        account_exclude: vec![],
+        account_required: vec![RAYDIUM_LAUNCHPAD_PROGRAM_ID.to_string().clone()],
+        signature: None,
+    };
+
+    let mut transaction_filters: HashMap<String, SubscribeRequestFilterTransactions> = HashMap::new();
+    transaction_filters.insert("raydium_launchpad_transaction_filter".to_string(), transaction_filter);
+
+    let yellowstone_grpc = YellowstoneGrpcGeyserClient::new(
+        env::var("GEYSER_URL").unwrap_or_default(),
+        env::var("X_TOKEN").ok(),
+        Some(CommitmentLevel::Confirmed),
+        HashMap::default(),
+        transaction_filters,
+        Default::default(),
+        Arc::new(RwLock::new(HashSet::new())),
+    );
+
+    let log_path =
+        env::var("LOG_PATH").unwrap_or_else(|_| "raydium_launchpad_events.log".to_string());
+    let file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)
+        .expect("Unable to open log file");
+    let file = Arc::new(Mutex::new(file));
+
+    carbon_core::pipeline::Pipeline::builder()
+        .datasource(yellowstone_grpc)
+        .metrics(Arc::new(LogMetrics::new()))
+        .metrics_flush_interval(3)
+        .instruction(
+            RaydiumLaunchpadDecoder,
+            RaydiumLaunchpadInstructionProcessor { file: file.clone() },
+        )
+        .shutdown_strategy(carbon_core::pipeline::ShutdownStrategy::Immediate)
+        .build()?
+        .run()
+        .await?;
+
+    Ok(())
+}
+
+pub struct RaydiumLaunchpadInstructionProcessor {
+    file: Arc<Mutex<std::fs::File>>,
+}
+
+#[async_trait]
+impl Processor for RaydiumLaunchpadInstructionProcessor {
+    type InputType = (
+        InstructionMetadata,
+        DecodedInstruction<RaydiumLaunchpadInstruction>,
+        NestedInstructions,
+        solana_instruction::Instruction,
+    );
+
+    async fn process(
+        &mut self,
+        (metadata, instruction, _nested_instructions, _): Self::InputType,
+        _metrics: Arc<MetricsCollection>,
+    ) -> CarbonResult<()> {
+        let signature = metadata.transaction_metadata.signature;
+        let json = serde_json::json!({
+            "signature": signature,
+            "instruction": instruction.data,
+        });
+        let mut file = self.file.lock().await;
+        writeln!(file, "{}", serde_json::to_string(&json)?)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- swap `RpcBlockSubscribe` for `YellowstoneGrpcGeyserClient` in the `raydium-launchpad-logger` example
- update example README to show Yellowstone environment variables

## Testing
- `cargo check -p raydium-launchpad-logger --quiet` *(failed to complete)*

------
https://chatgpt.com/codex/tasks/task_e_686f93753de8832daa634effaf4a9d80